### PR TITLE
Implement File Logger Plugin for MCP Data

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,1 +1,4 @@
 from .example_plugin import ExamplePlugin
+from .file_logger_plugin import FileLoggerPlugin
+
+__all__ = ['ExamplePlugin', 'FileLoggerPlugin']

--- a/plugins/file_logger_plugin.py
+++ b/plugins/file_logger_plugin.py
@@ -1,0 +1,17 @@
+import json
+
+class FileLoggerPlugin:
+    def __init__(self):
+        self.log_file = 'mcp_data.log'
+
+    def process_data(self, data):
+        try:
+            with open(self.log_file, 'a') as f:
+                json.dump(data, f)
+                f.write('\n') # Add newline for readability
+        except Exception as e:
+            print(f"Error writing to log file: {e}")
+
+    def close(self):
+        # Optional: close any resources if needed upon server shutdown
+        pass


### PR DESCRIPTION
This PR implements a `FileLoggerPlugin` that logs the processed MCP data to a file named `mcp_data.log`. The plugin serializes the data to JSON format and appends it to the log file, adding a newline character for readability.

**Changes:**

*   **Added `file_logger_plugin.py`:** This file contains the `FileLoggerPlugin` class, which implements the `process_data` method to log MCP data to a file.
*   **Modified `__init__.py`:** This file now imports and exports the `FileLoggerPlugin` to make it available for use.

**Reasoning:**

This plugin addresses the issue of needing a simple way to persist and inspect the MCP data processed by the system. Logging to a file provides a basic yet effective mechanism for debugging and data analysis.

**Testing:**

*   Manually tested by integrating the plugin into a dummy MCP processing pipeline.
*   Verified that the `mcp_data.log` file is created and that MCP data is correctly logged in JSON format.
*   Confirmed that the logging process doesn't interrupt the main program flow.

Further testing should involve larger datasets and stress testing to ensure robustness.